### PR TITLE
Day-2 DataSource 인터페이스와 HikariCP

### DIFF
--- a/src/main/java/hello/jdbc/repository/MemberRepositoryV1.java
+++ b/src/main/java/hello/jdbc/repository/MemberRepositoryV1.java
@@ -1,0 +1,143 @@
+package hello.jdbc.repository;
+
+import hello.jdbc.domain.Member;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.support.JdbcUtils;
+
+import javax.sql.DataSource;
+import java.sql.*;
+import java.util.NoSuchElementException;
+
+/**
+ * JDBC - DataSource, JdbcUtils 사용
+ */
+@Slf4j
+public class MemberRepositoryV1 {
+
+    private final DataSource dataSource;
+
+    public MemberRepositoryV1(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public Member save(Member member) throws SQLException {
+        String sql = "insert into member(member_id, money) values (?, ?)";
+
+        Connection connection = null;
+        PreparedStatement preparedStatement = null;
+
+        connection = getConnection();
+
+        try {
+            preparedStatement = connection.prepareStatement(sql);
+            preparedStatement.setString(1, member.getMemberId());
+            preparedStatement.setInt(2, member.getMoney());
+
+            preparedStatement.executeUpdate();
+
+            return member;
+        } catch (SQLException e) {
+            log.info("DB Error", e);
+            throw e;
+        } finally {
+            // preparedStatement.close(); // If, 이 곳에서 Exception 이 터지면? connection.close(); 은 실행이 안 된다.
+            // connection.close();
+            close(connection, preparedStatement, null);
+        }
+    }
+
+    public Member findById(String memberId) throws SQLException {
+        String sql = "select * from member where member_id = ?";
+
+        Connection connection = null;
+        PreparedStatement preparedStatement = null;
+        ResultSet resultSet = null;
+
+        try {
+            connection = getConnection();
+            preparedStatement = connection.prepareStatement(sql);
+            preparedStatement.setString(1, memberId);
+
+            resultSet = preparedStatement.executeQuery();// ResultSet을 반환 해준다.
+
+            if (resultSet.next()) {
+                Member member = new Member();
+                member.setMemberId(resultSet.getString("member_id"));
+                member.setMoney(resultSet.getInt("money"));
+
+                return member;
+            }
+
+            throw new NoSuchElementException("Member Not Found. MemberId = " + memberId);
+
+        } catch (SQLException e) {
+            log.error("DB Error");
+            throw e;
+
+        } finally {
+            close(connection, preparedStatement, resultSet);
+        }
+    }
+
+    public void update(String memberId, int money) throws SQLException {
+        String sql = "update member set money = ? where member_id = ?";
+
+        Connection connection = null;
+        PreparedStatement preparedStatement = null;
+
+        try {
+            connection = getConnection();
+            preparedStatement = connection.prepareStatement(sql);
+            preparedStatement.setInt(1, money);
+            preparedStatement.setString(2, memberId);
+
+            int resultSize = preparedStatement.executeUpdate(); // rows의 크기이다. 여기선 하나만 업데이트 하기 때문에 1이 리턴.
+
+            log.info("result size is {}", resultSize);
+
+        } catch (SQLException e) {
+            log.error("DB Error");
+            throw e;
+
+        } finally {
+            close(connection, preparedStatement, null);
+        }
+    }
+
+    public void delete(String memberId) throws SQLException {
+        String sql = "delete from member where member_id = ?";
+
+        Connection connection = null;
+        PreparedStatement preparedStatement = null;
+
+        try {
+            connection = getConnection();
+            preparedStatement = connection.prepareStatement(sql);
+            preparedStatement.setString(1, memberId);
+
+            int resultSize = preparedStatement.executeUpdate(); // rows의 크기이다. 여기선 하나만 업데이트 하기 때문에 1이 리턴.
+
+            log.info("result size is {}", resultSize);
+
+        } catch (SQLException e) {
+            log.error("DB Error");
+            throw e;
+
+        } finally {
+            close(connection, preparedStatement, null);
+        }
+    }
+
+    private static void close(Connection connection, Statement statement, ResultSet resultSet) {
+        JdbcUtils.closeResultSet(resultSet);
+        JdbcUtils.closeStatement(statement);
+        JdbcUtils.closeConnection(connection);
+    }
+
+    private Connection getConnection() throws SQLException {
+        Connection connection = dataSource.getConnection();
+        log.info("Get Connection = {}, class = {}", connection, connection.getClass());
+        return connection;
+    }
+
+}

--- a/src/test/java/hello/jdbc/connection/ConnectionTest.java
+++ b/src/test/java/hello/jdbc/connection/ConnectionTest.java
@@ -1,0 +1,43 @@
+package hello.jdbc.connection;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import static hello.jdbc.connection.ConnectionConst.*;
+
+@Slf4j
+class ConnectionTest {
+
+    @Test
+    void driverManager() throws SQLException {
+        // getConnection 시, URL, USERNAME, PASSWORD 등 설정 정보를 계속해서 넘겨야 한다. 매우 불편
+        Connection connection1 = DriverManager.getConnection(URL, USERNAME, PASSWORD);
+        Connection connection2 = DriverManager.getConnection(URL, USERNAME, PASSWORD);
+
+        log.info("Connection = {}, class = {}", connection1, connection1.getClass());
+        log.info("Connection = {}, class = {}", connection2, connection2.getClass());
+    }
+
+    @Test
+    void dataSourceManager() throws SQLException {
+        // DriverManagerDataSource - 항상 새로운 커넥션을 획득
+        // 이 객체가 만들어 지는 시점에 URL, USERNAME, PASSWORD 를 세팅해 놓으면 사용할 때 설정 정보를 계속해서 넘겨주지 않고 getConnection() 만 호출하면 됨.
+        DriverManagerDataSource driverManagerDataSource = new DriverManagerDataSource(URL, USERNAME, PASSWORD);
+        useDataSource(driverManagerDataSource);
+    }
+
+    private void useDataSource(DataSource dataSource) throws SQLException {
+        Connection connection1 = dataSource.getConnection();
+        Connection connection2 = dataSource.getConnection();
+
+        log.info("Connection = {}, class = {}", connection1, connection1.getClass());
+        log.info("Connection = {}, class = {}", connection2, connection2.getClass());
+    }
+
+}

--- a/src/test/java/hello/jdbc/connection/ConnectionTest.java
+++ b/src/test/java/hello/jdbc/connection/ConnectionTest.java
@@ -1,5 +1,6 @@
 package hello.jdbc.connection;
 
+import com.zaxxer.hikari.HikariDataSource;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
@@ -30,6 +31,20 @@ class ConnectionTest {
         // 이 객체가 만들어 지는 시점에 URL, USERNAME, PASSWORD 를 세팅해 놓으면 사용할 때 설정 정보를 계속해서 넘겨주지 않고 getConnection() 만 호출하면 됨.
         DriverManagerDataSource driverManagerDataSource = new DriverManagerDataSource(URL, USERNAME, PASSWORD);
         useDataSource(driverManagerDataSource);
+    }
+
+    @Test
+    void dataSourceConnectionPool() throws SQLException, InterruptedException {
+        // 커넥션 풀링
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl(URL);
+        dataSource.setUsername(USERNAME);
+        dataSource.setPassword(PASSWORD);
+        dataSource.setMaximumPoolSize(10);
+        dataSource.setPoolName("Hongki Pool");
+
+        useDataSource(dataSource);
+        Thread.sleep(1000);
     }
 
     private void useDataSource(DataSource dataSource) throws SQLException {

--- a/src/test/java/hello/jdbc/repository/MemberRepositoryV1Test.java
+++ b/src/test/java/hello/jdbc/repository/MemberRepositoryV1Test.java
@@ -1,0 +1,68 @@
+package hello.jdbc.repository;
+
+import com.zaxxer.hikari.HikariDataSource;
+import hello.jdbc.domain.Member;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.util.NoSuchElementException;
+
+import static hello.jdbc.connection.ConnectionConst.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Slf4j
+class MemberRepositoryV1Test {
+
+    MemberRepositoryV1 repository;
+
+    @BeforeEach
+    void beforeEach() {
+        // 기본 DriverManager - 항상 새로운 커넥션을 획득 (할 때 마다 TCP/IP로 커넥션을 맺기에 속도가 느리다.)
+        //DriverManagerDataSource dataSource = new DriverManagerDataSource(URL, USERNAME, PASSWORD);
+
+        // 커넥션 풀링.
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl(URL);
+        dataSource.setUsername(USERNAME);
+        dataSource.setPassword(PASSWORD);
+
+        repository = new MemberRepositoryV1(dataSource);
+    }
+
+    @Test
+    @DisplayName("Member CRUD 테스트")
+    void crud() throws SQLException, InterruptedException {
+        // Save.
+        Member member = new Member("member224", 10000);
+
+        repository.save(member);
+
+        // Read.
+        Member findMember = repository.findById(member.getMemberId());
+        log.info("findMember = {}", findMember);
+        log.info("findMember = {}", member.equals(findMember));
+        assertThat(findMember).isEqualTo(member);
+
+        // Update.
+        repository.update(member.getMemberId(), 20000);
+
+        // Read for update.
+        Member updatedMember = repository.findById(member.getMemberId());
+        assertThat(member.getMoney()).isNotEqualTo(updatedMember.getMoney());
+        assertThat(updatedMember.getMoney()).isEqualTo(20000);
+
+        // Delete.
+        repository.delete(member.getMemberId());
+
+        // Read for delete.
+        assertThatThrownBy(() -> repository.findById(member.getMemberId()))
+                .isInstanceOf(NoSuchElementException.class);
+
+        Thread.sleep(1000);
+    }
+
+}


### PR DESCRIPTION
`DataSource` : Connection을 획득하는 `방법`을 추상화 하는 인터페이스이다. 예를 들어, DBCP2를 사용하다가 HikariCP로 교체하고 싶다고 하자. 두 가지 모두 DataSource 인터페이스를 구현한 구현체이기 때문에 쉽게 교체가 가능하다.

[DriverManagerDataSource와 HikariDataSource의 차이]

`DriverManagerDataSource` : 통신을 할 때, 항상 커넥션 객체를 생성해서 TCP/IP 형태로 DB와 통신한다.
`HikariDataSource` : 커넥션 풀을 이용하여 커넥션 객체를 생성해두고 (default : 10개) 재사용 한다.